### PR TITLE
 #35 修复ui界面查询数据表列过多问题+更新mybatis-generator-plugin版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.itfsw</groupId>
             <artifactId>mybatis-generator-plugin</artifactId>
-            <version>1.2.9</version>
+            <version>1.2.12</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/spawpaw/mybatis/generator/gui/DatabaseConfig.java
+++ b/src/main/java/com/spawpaw/mybatis/generator/gui/DatabaseConfig.java
@@ -152,7 +152,7 @@ public class DatabaseConfig implements Serializable {
         //获取每个表中的字段信息
         for (String tableName : tmpList) {
             //生成表的基本信息（每个字段的名称、类型）
-            rs = meta.getColumns(null, null, tableName, null);
+            rs = meta.getColumns(dbName.getValue().isEmpty() ? null : dbName.getValue(), null, tableName, null);
             while (rs.next()) {
                 TableColumnMetaData columnMetaData = new TableColumnMetaData();
                 columnMetaData.setColumnName(rs.getString("COLUMN_NAME"));

--- a/src/main/java/com/spawpaw/mybatis/generator/gui/util/MBGRunner.java
+++ b/src/main/java/com/spawpaw/mybatis/generator/gui/util/MBGRunner.java
@@ -136,6 +136,7 @@ public class MBGRunner {
 
         //========================================================================================================table
         TableConfiguration tableConfiguration = new TableConfiguration(context);
+        tableConfiguration.setCatalog(databaseConfig.dbName.getValue());
         tableConfiguration.setTableName(projectConfig.selectedTable.getValue());
         tableConfiguration.setDomainObjectName(projectConfig.entityObjName.getValue().replace(" ", ""));
         tableConfiguration.setMapperName(projectConfig.daoObjName.getValue().replace(" ", ""));


### PR DESCRIPTION
修复一个MYSQL数据库中,含有同名的表,会导致生成的时候获取到同名表的列名的BUG.
原因:获取表的列时,没有按照数据库名去取,会取到所有数据库同名表的列名
修改文件名
com.spawpaw.mybatis.generator.gui.DatabaseConfig

```JAVA
rs = meta.getColumns(null, null, tableName, null);
//改为
rs = meta.getColumns(dbName.getValue().isEmpty() ? null : dbName.getValue(), null, tableName, null);
```
更新
1.2.9->1.2.12
```XML
<dependency>
            <groupId>com.itfsw</groupId>
            <artifactId>mybatis-generator-plugin</artifactId>
            <version>1.2.12</version>
        </dependency>
```